### PR TITLE
ci(GitHub): Fix the race condition in caching jobs

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -39,17 +39,6 @@ jobs:
               # https://github.com/actions/checkout
               uses: actions/checkout@v4
 
-            # FIXME: Delete this if the solution works
-            # - name: Setup Rust
-            #   # https://github.com/moonrepo/setup-rust
-            #   uses: moonrepo/setup-rust@v1
-            #   env:
-            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            #   with:
-            #       cache: true
-            #       components: clippy
-            #       channel: ${{ inputs.toolchain }}
-            #       profile: minimal
             - name: Setup Rust
               # https://github.com/dtolnay/rust-toolchain
               uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -33,22 +33,36 @@ jobs:
         outputs:
             status: ${{ steps.failure.outputs.status || steps.success.outputs.status }}
         runs-on: ubuntu-latest
-        timeout-minutes: 3
+        timeout-minutes: 2
         steps:
             - name: Checkout to the repository
               # https://github.com/actions/checkout
               uses: actions/checkout@v4
 
+            # FIXME: Delete this if the solution works
+            # - name: Setup Rust
+            #   # https://github.com/moonrepo/setup-rust
+            #   uses: moonrepo/setup-rust@v1
+            #   env:
+            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            #   with:
+            #       cache: true
+            #       components: clippy
+            #       channel: ${{ inputs.toolchain }}
+            #       profile: minimal
             - name: Setup Rust
-              # https://github.com/moonrepo/setup-rust
-              uses: moonrepo/setup-rust@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              # https://github.com/dtolnay/rust-toolchain
+              uses: dtolnay/rust-toolchain@stable
+              id: toolchain
               with:
-                  cache: true
                   components: clippy
-                  channel: ${{ inputs.toolchain }}
-                  profile: minimal
+                  toolchain: ${{ inputs.toolchain }}
+
+            - name: Setup the cache
+              # https://github.com/Swatinem/rust-cache
+              uses: Swatinem/rust-cache@v2
+              with:
+                  key: ${{ inputs.toolchain }}-${{ steps.toolchain.outputs.cachekey }}-clippy
 
             - name: Check Rust codebase with Clippy
               # https://github.com/giraffate/clippy-action

--- a/.github/workflows/hack.yml
+++ b/.github/workflows/hack.yml
@@ -35,17 +35,6 @@ jobs:
               # https://github.com/actions/checkout
               uses: actions/checkout@v4
 
-            # FIXME: Delete this if the solution works
-            # - name: Setup Rust
-            #   # https://github.com/moonrepo/setup-rust
-            #   uses: moonrepo/setup-rust@v1
-            #   env:
-            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            #   with:
-            #       bins: cargo-hack
-            #       cache: true
-            #       channel: ${{ inputs.toolchain }}
-            #       profile: minimal
             - name: Setup Rust
               # https://github.com/dtolnay/rust-toolchain
               uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/hack.yml
+++ b/.github/workflows/hack.yml
@@ -29,22 +29,42 @@ jobs:
         outputs:
             status: ${{ steps.failure.outputs.status || steps.success.outputs.status }}
         runs-on: ubuntu-latest
-        timeout-minutes: 3
+        timeout-minutes: 2
         steps:
             - name: Checkout to the repository
               # https://github.com/actions/checkout
               uses: actions/checkout@v4
 
+            # FIXME: Delete this if the solution works
+            # - name: Setup Rust
+            #   # https://github.com/moonrepo/setup-rust
+            #   uses: moonrepo/setup-rust@v1
+            #   env:
+            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            #   with:
+            #       bins: cargo-hack
+            #       cache: true
+            #       channel: ${{ inputs.toolchain }}
+            #       profile: minimal
             - name: Setup Rust
-              # https://github.com/moonrepo/setup-rust
-              uses: moonrepo/setup-rust@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              # https://github.com/dtolnay/rust-toolchain
+              uses: dtolnay/rust-toolchain@stable
+              id: toolchain
               with:
-                  bins: cargo-hack
-                  cache: true
-                  channel: ${{ inputs.toolchain }}
-                  profile: minimal
+                  components: ""
+                  toolchain: ${{ inputs.toolchain }}
+
+            - name: Install cargo extensions binaries
+              # https://github.com/taiki-e/install-action
+              uses: taiki-e/install-action@v2
+              with:
+                  tool: cargo-hack
+
+            - name: Setup the cache
+              # https://github.com/Swatinem/rust-cache
+              uses: Swatinem/rust-cache@v2
+              with:
+                  key: ${{ inputs.toolchain }}-${{ steps.toolchain.outputs.cachekey }}-hack
 
             - name: Check if the code compiles with cargo hack
               run: cargo hack check --feature-powerset --ignore-private --no-dev-deps --workspace

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -29,22 +29,42 @@ jobs:
         outputs:
             status: ${{ steps.failure.outputs.status || steps.success.outputs.status }}
         runs-on: ubuntu-latest
-        timeout-minutes: 3
+        timeout-minutes: 2
         steps:
             - name: Checkout to the repository
               # https://github.com/actions/checkout
               uses: actions/checkout@v4
 
+            # FIXME: Delete this if the solution works
+            # - name: Setup Rust
+            #   # https://github.com/moonrepo/setup-rust
+            #   uses: moonrepo/setup-rust@v1
+            #   env:
+            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            #   with:
+            #       bins: cargo-nextest
+            #       cache: true
+            #       channel: ${{ inputs.toolchain }}
+            #       profile: minimal
             - name: Setup Rust
-              # https://github.com/moonrepo/setup-rust
-              uses: moonrepo/setup-rust@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              # https://github.com/dtolnay/rust-toolchain
+              uses: dtolnay/rust-toolchain@stable
+              id: toolchain
               with:
-                  bins: cargo-nextest
-                  cache: true
-                  channel: ${{ inputs.toolchain }}
-                  profile: minimal
+                  components: ""
+                  toolchain: ${{ inputs.toolchain }}
+
+            - name: Install cargo extensions binaries
+              # https://github.com/taiki-e/install-action
+              uses: taiki-e/install-action@v2
+              with:
+                  tool: cargo-nextest
+
+            - name: Setup the cache
+              # https://github.com/Swatinem/rust-cache
+              uses: Swatinem/rust-cache@v2
+              with:
+                  key: ${{ inputs.toolchain }}-${{ steps.toolchain.outputs.cachekey }}-nextest
 
             - name: Run tests with latest nextest release
               run: cargo nextest run --all-features --profile ci

--- a/.github/workflows/nextest.yml
+++ b/.github/workflows/nextest.yml
@@ -35,17 +35,6 @@ jobs:
               # https://github.com/actions/checkout
               uses: actions/checkout@v4
 
-            # FIXME: Delete this if the solution works
-            # - name: Setup Rust
-            #   # https://github.com/moonrepo/setup-rust
-            #   uses: moonrepo/setup-rust@v1
-            #   env:
-            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            #   with:
-            #       bins: cargo-nextest
-            #       cache: true
-            #       channel: ${{ inputs.toolchain }}
-            #       profile: minimal
             - name: Setup Rust
               # https://github.com/dtolnay/rust-toolchain
               uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -41,16 +41,30 @@ jobs:
               # https://github.com/actions/checkout
               uses: actions/checkout@v4
 
+            # FIXME: Delete this if the solution works
+            # - name: Setup Rust
+            #   # https://github.com/moonrepo/setup-rust
+            #   uses: moonrepo/setup-rust@v1
+            #   env:
+            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            #   with:
+            #       cache: true
+            #       components: rustfmt
+            #       channel: ${{ inputs.toolchain }}
+            #       profile: minimal
             - name: Setup Rust
-              # https://github.com/moonrepo/setup-rust
-              uses: moonrepo/setup-rust@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              # https://github.com/dtolnay/rust-toolchain
+              uses: dtolnay/rust-toolchain@stable
+              id: toolchain
               with:
-                  cache: true
                   components: rustfmt
-                  channel: ${{ inputs.toolchain }}
-                  profile: minimal
+                  toolchain: ${{ inputs.toolchain }}
+
+            - name: Setup the cache
+              # https://github.com/Swatinem/rust-cache
+              uses: Swatinem/rust-cache@v2
+              with:
+                  key: ${{ inputs.toolchain }}-${{ steps.toolchain.outputs.cachekey }}-rustfmt
 
             - name: Check Rust codebase format with rustfmt
               # https://github.com/LoliGothick/rustfmt-check

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -41,17 +41,6 @@ jobs:
               # https://github.com/actions/checkout
               uses: actions/checkout@v4
 
-            # FIXME: Delete this if the solution works
-            # - name: Setup Rust
-            #   # https://github.com/moonrepo/setup-rust
-            #   uses: moonrepo/setup-rust@v1
-            #   env:
-            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            #   with:
-            #       cache: true
-            #       components: rustfmt
-            #       channel: ${{ inputs.toolchain }}
-            #       profile: minimal
             - name: Setup Rust
               # https://github.com/dtolnay/rust-toolchain
               uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Description

Resolves #49

## Explanation

I replaced the actions used for setting up the Rust toolchain _(previously we used the one that was supposed to cover everything - including caching)_, and added separate actions:
1. for setting up cache where we provide own cache `key` - based on the toolchain and workflow name
2. for installing cargo extension binaries - used in workflows that requires it