### PR TITLE
chore(Cargo): Unify `lints` at the workspace manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,32 @@ version = "0.1.0"
 [workspace.dependencies]
 strum = { version = "0.25.0", default-features = false }
 strum_macros = { version = "0.25.3", default-features = false }
+
+[workspace.lints.clippy]
+# Deny
+all = "deny"
+cargo = "deny"
+complexity = "deny"
+correctness = "deny"
+nursery = "deny"
+pedantic = "deny"
+perf = "deny"
+suspicious = "deny"
+cast_possible_truncation = "deny"
+cast_precision_loss = "deny"
+unwrap_used = "deny"
+# Allow
+derive_partial_eq_without_eq = "allow"
+module_name_repetitions = "allow"
+
+[workspace.lints.rust]
+missing_debug_implementations = "deny"
+rust_2018_idioms = "deny"
+unused_must_use = "deny"
+unused_lifetimes = "deny"
+unused_results = "deny"
+# Warn
+unused_tuple_struct_fields = "warn"
+unused_crate_dependencies = "warn"
+# Allow
+ambiguous_glob_reexports = "allow"

--- a/crates/polished-css-macros/Cargo.toml
+++ b/crates/polished-css-macros/Cargo.toml
@@ -10,8 +10,8 @@ description = "Procedural macros which support the development of a library crat
 categories = ["graphics", "gui", "rendering", "wasm", "web-programming"]
 keywords = ["macros"]
 authors = [
-  "Mateusz Kadlubowski <xeho91@pm.me>",
-  "Vincent Chapuis <vincent.professional@chapuis.ovh>",
+	"Mateusz Kadlubowski <xeho91@pm.me>",
+	"Vincent Chapuis <vincent.professional@chapuis.ovh>",
 ]
 documentation = { workspace = true }
 homepage = { workspace = true }
@@ -30,3 +30,6 @@ syn = { version = "2.0.39" }
 
 [lib]
 proc-macro = true
+
+[lints]
+workspace = true

--- a/crates/polished-css-macros/src/lib.rs
+++ b/crates/polished-css-macros/src/lib.rs
@@ -1,31 +1,3 @@
-#![deny(
-	clippy::all,
-    // Groups
-	clippy::cargo,
-	clippy::complexity,
-	clippy::correctness,
-	clippy::nursery,
-	clippy::pedantic,
-	clippy::perf,
-	clippy::suspicious,
-    // Adjustments
-	clippy::cast_possible_truncation,
-	clippy::cast_precision_loss,
-	clippy::unwrap_used,
-	// missing_docs,
-	missing_debug_implementations,
-	rust_2018_idioms,
-	unused_must_use,
-	unused_lifetimes,
-	unused_results
-)]
-#![warn(unused_tuple_struct_fields, unused_crate_dependencies)]
-#![allow(
-	clippy::derive_partial_eq_without_eq,
-	clippy::module_name_repetitions,
-	ambiguous_glob_reexports
-)]
-
 mod attribute;
 mod derive;
 mod utils;

--- a/crates/polished-css/Cargo.toml
+++ b/crates/polished-css/Cargo.toml
@@ -32,3 +32,6 @@ regex = { version = "1.10.2" }
 strum_macros = { workspace = true }
 typed-builder = { version = "0.18.0" }
 yew = { version = "0.21.0", optional = true }
+
+[lints]
+workspace = true

--- a/crates/polished-css/src/lib.rs
+++ b/crates/polished-css/src/lib.rs
@@ -1,31 +1,4 @@
 #![feature(const_trait_impl)]
-#![deny(
-	clippy::all,
-    // Groups
-	clippy::cargo,
-	clippy::complexity,
-	clippy::correctness,
-	clippy::nursery,
-	clippy::pedantic,
-	clippy::perf,
-	clippy::suspicious,
-    // Adjustments
-	clippy::cast_possible_truncation,
-	clippy::cast_precision_loss,
-	clippy::unwrap_used,
-	// missing_docs,
-	missing_debug_implementations,
-	rust_2018_idioms,
-	unused_must_use,
-	unused_lifetimes,
-	unused_results
-)]
-#![warn(unused_tuple_struct_fields, unused_crate_dependencies)]
-#![allow(
-	clippy::derive_partial_eq_without_eq,
-	clippy::module_name_repetitions,
-	ambiguous_glob_reexports
-)]
 
 #[cfg(feature = "atomic")]
 pub mod atomic;


### PR DESCRIPTION
## Resources

- https://doc.rust-lang.org/cargo/reference/manifest.html#the-lints-section