### PR TITLE
perf(selector/class): use singleton when init the regex for char esca…

### DIFF
--- a/crates/polished-css/Cargo.toml
+++ b/crates/polished-css/Cargo.toml
@@ -20,13 +20,13 @@ repository = { workspace = true }
 readme = { workspace = true }
 
 [features]
-atomic = ["dep:once_cell"]
+atomic = []
 yew = ["atomic", "dep:yew"]
 
 [dependencies]
 polished-css-macros = { path = "../polished-css-macros", version = "0.1.0" }
 
-once_cell = { version = "1.18.0", optional = true }
+once_cell = { version = "1.18.0" }
 paste = { version = "1.0.14" }
 regex = { version = "1.10.2", default-features = false }
 strum_macros = { workspace = true }

--- a/crates/polished-css/src/selector/class.rs
+++ b/crates/polished-css/src/selector/class.rs
@@ -1,3 +1,4 @@
+use once_cell::sync::OnceCell;
 use regex::{Captures, Regex};
 
 use super::SelectorDisplay;
@@ -31,13 +32,18 @@ impl From<&str> for Class {
 	}
 }
 
+static SPECIAL_CHAR_REGEX: OnceCell<Regex> = OnceCell::new();
+
 /// # Panics
 ///
-/// Pacnis when the Regex couldn't be created
+/// Panic when the Regex couldn't be created
 #[must_use]
 pub fn escape_special_chars_in_class_name(value: &str) -> String {
-	Regex::new(r#"[!@#$%^&*()+\=\[\]{};':"\\|,.<>\\/?]"#)
-		.expect("Failed to create a regex for matching special characters in CSS class name.")
+	let regex = SPECIAL_CHAR_REGEX.get_or_init(|| {
+		Regex::new(r#"[!@#$%^&*()+\=\[\]{};':"\\|,.<>\\/?]"#)
+			.expect("Failed to create a regex for matching special characters in CSS class name.")
+	});
+	regex
 		.replace_all(value, |caps: &Captures<'_>| {
 			caps.iter()
 				.map(|char| char.map_or_else(String::new, |char| format!("\\{}", char.as_str())))


### PR DESCRIPTION
We initialize the regex whenever we call fn `escape_special_chars_in_class_name`.

Using `OnceCell::get_or_init` helps us improve the performance.